### PR TITLE
Add hex sticker generation script for fpr package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^man/figures$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,7 @@ Imports:
 Remotes: 
     poissonconsulting/fwapgr,
     nsgrantham/ggdark
-Suggests: 
-    testthat (>= 3.0.0)
+Suggests:
+    testthat (>= 3.0.0),
+    hexSticker
 Config/testthat/edition: 3

--- a/data-raw/README_hexsticker.md
+++ b/data-raw/README_hexsticker.md
@@ -1,0 +1,43 @@
+# Hex Sticker Generation
+
+This directory contains the script to generate the hex sticker for the `fpr` package.
+
+## Quick Start
+
+To generate the hex sticker, simply run:
+
+```r
+source("data-raw/make_hexsticker.R")
+```
+
+This will:
+1. Download the NG logo icon (if not already present)
+2. Generate a high-resolution hex sticker at `man/figures/logo.png`
+3. Generate a web-optimized version at `man/figures/logo_small.png`
+
+## Customization
+
+All customizable parameters are at the top of `make_hexsticker.R`:
+
+- **Logo URL**: Where to download the NG icon from
+- **Logo positioning**: `s_x`, `s_y` - adjust the icon position
+- **Logo size**: `s_width`, `s_height` - adjust the icon size
+- **Package name styling**: `p_size`, `p_x`, `p_y`, `p_color` - adjust text appearance
+- **Hex sticker colors**: `h_fill` (background), `h_color` (border)
+- **Border thickness**: `h_size`
+- **Output resolution**: `dpi` - higher values = better quality but larger files
+
+## Design Specifications
+
+The current design features:
+- Black background with white border
+- NG logo icon in white, centered in the upper portion
+- Package name "fpr" in white, centered below the icon
+- 300 DPI for print quality, 150 DPI for web use
+
+## Template for Other Packages
+
+This script can be easily adapted for other packages (dff, dfp) by:
+1. Copying `make_hexsticker.R` to the other package
+2. Updating the `package_name` variable
+3. Adjusting any other parameters as needed

--- a/data-raw/make_hexsticker.R
+++ b/data-raw/make_hexsticker.R
@@ -1,0 +1,75 @@
+# Script to generate hex sticker for fpr package
+# Uses hexSticker package to create a simple black and white design
+# with NG logo icon and package name
+
+# Install hexSticker if not already installed
+if (!requireNamespace("hexSticker", quietly = TRUE)) {
+  install.packages("hexSticker")
+}
+
+library(hexSticker)
+
+# Configuration parameters (easy to tweak)
+logo_url <- "https://raw.githubusercontent.com/NewGraphEnvironment/new_graphiti/main/assets/logos/logo_newgraph/WHITE/PNG/nge-icon_white.png"
+logo_file <- "data-raw/nge-icon_white.png"
+output_file <- "man/figures/logo.png"
+package_name <- "fpr"
+
+# Download the logo if it doesn't exist locally
+if (!file.exists(logo_file)) {
+  dir.create(dirname(logo_file), recursive = TRUE, showWarnings = FALSE)
+  download.file(logo_url, logo_file, mode = "wb")
+  message("Downloaded NG logo to ", logo_file)
+} else {
+  message("Using existing logo at ", logo_file)
+}
+
+# Create output directory if it doesn't exist
+dir.create(dirname(output_file), recursive = TRUE, showWarnings = FALSE)
+
+# Generate hex sticker
+sticker(
+  subplot = logo_file,
+  package = package_name,
+  # Logo positioning and size
+  s_x = 1,           # Logo x position (center)
+  s_y = 0.75,        # Logo y position (slightly above center)
+  s_width = 0.4,     # Logo width
+  s_height = 0.4,    # Logo height (will maintain aspect ratio)
+  # Package name styling
+  p_size = 20,       # Package name font size
+  p_x = 1,           # Package name x position (center)
+  p_y = 1.45,        # Package name y position (below logo)
+  p_color = "white", # Package name color
+  # Hex sticker styling
+  h_fill = "black",  # Background fill color
+  h_color = "white", # Border color
+  h_size = 1.5,      # Border thickness
+  # Output settings
+  filename = output_file,
+  dpi = 300          # High resolution for quality
+)
+
+message("Hex sticker generated successfully at ", output_file)
+
+# Optional: Also create a smaller version for README
+readme_logo <- "man/figures/logo_small.png"
+sticker(
+  subplot = logo_file,
+  package = package_name,
+  s_x = 1,
+  s_y = 0.75,
+  s_width = 0.4,
+  s_height = 0.4,
+  p_size = 20,
+  p_x = 1,
+  p_y = 1.45,
+  p_color = "white",
+  h_fill = "black",
+  h_color = "white",
+  h_size = 1.5,
+  filename = readme_logo,
+  dpi = 150  # Lower DPI for web display
+)
+
+message("Small version created at ", readme_logo)


### PR DESCRIPTION
- Created data-raw/make_hexsticker.R with fully scripted hex generation
- Script downloads NG logo and generates black & white hex sticker
- All parameters easily customizable for tweaking design
- Added hexSticker to Suggests in DESCRIPTION
- Added man/figures to .Rbuildignore
- Included documentation in README_hexsticker.md
- Design can serve as template for dff and dfp packages